### PR TITLE
Add TypeScript typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ $ npm install --save-dev mocha-testdata
 
 Here's a basic example with the BDD interface:
 
-```js
-var assert = require('assert');
-var given = require('mocha-testdata');
+```ts
+import * as assert from assert;
+import { given } from mocha-testdata;
 
-describe('My test suite', function() {
-  given('', false, null, undefined).it('passes if value is falsey', function(value) {
+describe('My test suite', function () {
+  given('', false, null, undefined).it('passes if value is falsey', function (value) {
     assert.ok(!value);
   });
 });
@@ -37,12 +37,12 @@ describe('My test suite', function() {
 
 And the same example with the TDD interface:
 
-```js
-var assert = require('assert');
-var withData = require('mocha-testdata');
+```ts
+import * as assert from assert;
+import { given } from mocha-testdata;
 
-suite('My test suite', function() {
-  withData('', false, null, undefined).test('passes if value is falsey', function(value) {
+suite('My test suite', function () {
+  withData('', false, null, undefined).test('passes if value is falsey', function (value) {
     assert.ok(!value);
   });
 });
@@ -52,11 +52,11 @@ suite('My test suite', function() {
 
 Assuming:
 
-```js
+```ts
 var testData = require('mocha-testdata');
 ```
 
-### `testData(data)`
+### `testData.given(data)`
 
 Defines set of test data for a test case.
 
@@ -74,25 +74,25 @@ Returns:
 
 Example with multiple arguments:
 
-```js
-var assert = require('assert');
-var testData = require('mocha-testdata');
+```ts
+import * as assert from assert;
+import { given } from mocha-testdata;
 
-suite('My test suite', function() {
-  testData([1, 2, 3], [3, 2, 1]).test('sum to 6', function(a, b, c) {
+suite('My test suite', function () {
+  given([1, 2, 3], [3, 2, 1]).test('sum to 6', function (a, b, c) {
     assert.strictEqual(a + b + c, 6);
   });
 });
 ```
 
 
-### `testData.async(data)`
+### `testData.givenAsync(data)`
 
 Defines set of test data for an async test case.
 
 #### data
 
-Same as [`testData`](#testdatadata).
+Same as [`testData.given(data)`](#data).
 
 Returns:
   - `it`: define an async test case (for use with BDD interface)
@@ -102,18 +102,54 @@ Async test cases take a callback as their first parameter; test data are passed 
 
 Example:
 
-```js
-var assert = require('assert');
-var testData = require('mocha-testdata');
+```ts
+import * as assert from assert;
+import { givenAsync } from mocha-testdata;
 
-suite('My async test suite', function() {
-  testData.async([1, 2, 3], [3, 2, 1]).test('sum to 6', function(done, a, b, c) {
+suite('My async test suite', function () {
+  givenAsync([1, 2, 3], [3, 2, 1]).test('sum to 6', function (done, a, b, c) {
     doSomethingAsync(function () {
       assert.strictEqual(a + b + c, 6);
       done();
     });
   });
 });
+```
+
+
+## TypeScript notes
+
+The following use-cases are currently supported by included TypeScript typings:
+
+```ts
+import { given, givenAsync } from "mocha-testdata";
+
+// simple data
+given(1, 2, 3, 4).it("One", arg => arg);
+givenAsync(1, 2, 3, 4).it("Two", (done, arg) => done());
+
+// simple predefined data
+const data = [1, 2, 3, 4];
+given(data).it("Three", arg => arg);
+givenAsync(data).it("Four", (done, arg) => done());
+
+// complex data
+given([1, 2], [3, 4]).it("Five", (a, b) => a);
+givenAsync([1, 2], [3, 4]).it("Six", (done, a, b) => done());
+
+// complex predefined data
+const complexData: { 0: number, 1: number }[] = [[1, 2], [3, 4]]; // explicit typing is required here, type inference is not good enough in TypeScript 1.8.9
+given(complexData).it("Seven", (a, b) => a);
+givenAsync(complexData).it("Eight", (done, a, b) => done());
+
+// structured data
+given({ a: 1, b: 2 }, { a: 1, b: 2 }).it("Nine", arg => arg.a);
+givenAsync({ a: 1, b: 2 }, { a: 1, b: 2 }).it("Ten", (done, arg) => arg.a && done());
+
+// structured predefined data
+const structuredData = [{ a: 1, b: 2 }, { a: 1, b: 2 }];
+given(structuredData).it("Eleven", arg => arg.a);
+givenAsync(structuredData).it("Twelve", (done, arg) => arg.a && done());
 ```
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript typings for "mocha-testdata@1.1.3".
+// TypeScript typings for "mocha-testdata@1.2.0".
 
 /** Fluent interface returned by "given". */
 interface MochaGivenMethods3<P1, P2, P3> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,27 +1,52 @@
 // TypeScript typings for "mocha-testdata@1.1.3".
 
-interface MochaGiven {
-    <P1, P2, P3>(...params: { 0: P1, 1: P2, 2: P3 }[]): MochaGivenMethods3<P1, P2, P3>;
-    <P1, P2>(...params: { 0: P1, 1: P2 }[]): MochaGivenMethods2<P1, P2>;
-    <P1>(...params: P1[]): MochaGivenMethods1<P1>;
-}
-
-interface MochaGivenMethods3<P1, P2, P3> {
-    it(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
-    test(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
-}
-
-interface MochaGivenMethods2<P1, P2> {
-    it(title: string, test: (p1: P1, p2: P2) => void): any;
-    test(title: string, test: (p1: P1, p2: P2) => void): any;
-}
-
-interface MochaGivenMethods1<P1> {
-    it(title: string, test: (p1: P1) => void): any;
-    test(title: string, test: (p1: P1) => void): any;
-}
-
 declare module "mocha-testdata" {
-    const given: MochaGiven;
-    export = given;
+
+    // for synchronous tests
+
+    interface MochaGivenMethods3<P1, P2, P3> {
+        it(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
+        test(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
+    }
+
+    interface MochaGivenMethods2<P1, P2> {
+        it(title: string, test: (p1: P1, p2: P2) => void): any;
+        test(title: string, test: (p1: P1, p2: P2) => void): any;
+    }
+
+    interface MochaGivenMethods1<P1> {
+        it(title: string, test: (p1: P1) => void): any;
+        test(title: string, test: (p1: P1) => void): any;
+    }
+
+    export function given<P1, P2, P3>(first: { 0: P1, 1: P2, 2: P3 } | { 0: P1, 1: P2, 2: P3 }[], ...params: { 0: P1, 1: P2, 2: P3 }[]): MochaGivenMethods3<P1, P2, P3>;
+    export function given<P1, P2>(first: { 0: P1, 1: P2 } | { 0: P1, 1: P2 }[], ...params: { 0: P1, 1: P2 }[]): MochaGivenMethods2<P1, P2>;
+    export function given<P1>(params: P1[]): MochaGivenMethods1<P1>;
+    export function given<P1>(...params: P1[]): MochaGivenMethods1<P1>;
+
+
+    // for asynchronous tests
+
+    type DoneHandler = { (): void };
+
+    interface MochaGivenAsyncMethods3<P1, P2, P3> {
+        it(title: string, test: (done: DoneHandler, p1: P1, p2: P2, p3: P3) => void): any;
+        test(title: string, test: (done: DoneHandler, p1: P1, p2: P2, p3: P3) => void): any;
+    }
+
+    interface MochaGivenAsyncMethods2<P1, P2> {
+        it(title: string, test: (done: DoneHandler, p1: P1, p2: P2) => void): any;
+        test(title: string, test: (done: DoneHandler, p1: P1, p2: P2) => void): any;
+    }
+
+    interface MochaGivenAsyncMethods1<P1> {
+        it(title: string, test: (done: DoneHandler, p1: P1) => void): any;
+        test(title: string, test: (done: DoneHandler, p1: P1) => void): any;
+    }
+
+    export function givenAsync<P1, P2, P3>(first: { 0: P1, 1: P2, 2: P3 } | { 0: P1, 1: P2, 2: P3 }[], ...params: { 0: P1, 1: P2, 2: P3 }[]): MochaGivenAsyncMethods3<P1, P2, P3>;
+    export function givenAsync<P1, P2>(first: { 0: P1, 1: P2 } | { 0: P1, 1: P2 }[], ...params: { 0: P1, 1: P2 }[]): MochaGivenAsyncMethods2<P1, P2>;
+    export function givenAsync<P1>(params: P1[]): MochaGivenAsyncMethods1<P1>;
+    export function givenAsync<P1>(...params: P1[]): MochaGivenAsyncMethods1<P1>;
+
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,52 +1,204 @@
 // TypeScript typings for "mocha-testdata@1.1.3".
 
-declare module "mocha-testdata" {
+/** Fluent interface returned by "given". */
+interface MochaGivenMethods3<P1, P2, P3> {
+    /** Defines a test case (for use with BDD interface). */
+    it(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
 
-    // for synchronous tests
-
-    interface MochaGivenMethods3<P1, P2, P3> {
-        it(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
-        test(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
-    }
-
-    interface MochaGivenMethods2<P1, P2> {
-        it(title: string, test: (p1: P1, p2: P2) => void): any;
-        test(title: string, test: (p1: P1, p2: P2) => void): any;
-    }
-
-    interface MochaGivenMethods1<P1> {
-        it(title: string, test: (p1: P1) => void): any;
-        test(title: string, test: (p1: P1) => void): any;
-    }
-
-    export function given<P1, P2, P3>(first: { 0: P1, 1: P2, 2: P3 } | { 0: P1, 1: P2, 2: P3 }[], ...params: { 0: P1, 1: P2, 2: P3 }[]): MochaGivenMethods3<P1, P2, P3>;
-    export function given<P1, P2>(first: { 0: P1, 1: P2 } | { 0: P1, 1: P2 }[], ...params: { 0: P1, 1: P2 }[]): MochaGivenMethods2<P1, P2>;
-    export function given<P1>(params: P1[]): MochaGivenMethods1<P1>;
-    export function given<P1>(...params: P1[]): MochaGivenMethods1<P1>;
-
-
-    // for asynchronous tests
-
-    type DoneHandler = { (): void };
-
-    interface MochaGivenAsyncMethods3<P1, P2, P3> {
-        it(title: string, test: (done: DoneHandler, p1: P1, p2: P2, p3: P3) => void): any;
-        test(title: string, test: (done: DoneHandler, p1: P1, p2: P2, p3: P3) => void): any;
-    }
-
-    interface MochaGivenAsyncMethods2<P1, P2> {
-        it(title: string, test: (done: DoneHandler, p1: P1, p2: P2) => void): any;
-        test(title: string, test: (done: DoneHandler, p1: P1, p2: P2) => void): any;
-    }
-
-    interface MochaGivenAsyncMethods1<P1> {
-        it(title: string, test: (done: DoneHandler, p1: P1) => void): any;
-        test(title: string, test: (done: DoneHandler, p1: P1) => void): any;
-    }
-
-    export function givenAsync<P1, P2, P3>(first: { 0: P1, 1: P2, 2: P3 } | { 0: P1, 1: P2, 2: P3 }[], ...params: { 0: P1, 1: P2, 2: P3 }[]): MochaGivenAsyncMethods3<P1, P2, P3>;
-    export function givenAsync<P1, P2>(first: { 0: P1, 1: P2 } | { 0: P1, 1: P2 }[], ...params: { 0: P1, 1: P2 }[]): MochaGivenAsyncMethods2<P1, P2>;
-    export function givenAsync<P1>(params: P1[]): MochaGivenAsyncMethods1<P1>;
-    export function givenAsync<P1>(...params: P1[]): MochaGivenAsyncMethods1<P1>;
-
+    /** Defines a test case (for use with TDD & qunit interfaces). */
+    test(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
 }
+
+/** Fluent interface returned by "given". */
+interface MochaGivenMethods2<P1, P2> {
+    /** Defines a test case (for use with BDD interface). */
+    it(title: string, test: (p1: P1, p2: P2) => void): any;
+
+    /** Defines a test case (for use with TDD & qunit interfaces). */
+    test(title: string, test: (p1: P1, p2: P2) => void): any;
+}
+
+/** Fluent interface returned by "given". */
+interface MochaGivenMethods1<P1> {
+    /** Defines a test case (for use with BDD interface). */
+    it(title: string, test: (p1: P1) => void): any;
+
+    /** Defines a test case (for use with TDD & qunit interfaces). */
+    test(title: string, test: (p1: P1) => void): any;
+}
+
+
+/**
+ * Defines set of test data for a test case.
+ *
+ * @param { Tuple | Tuple[] } first
+ *     Values to pass to the test. If the arguments themselves are arrays,
+ *     they will be passed as multiple arguments to the test function.
+ *     If a data item is an object, the "description" property is used
+ *     to construct the individual test name.
+ *
+ * @param { Tuple[] } params
+ *     Additional values to pass to the test.
+ *
+ * @returns
+ *     Fluent interface to define the test that will receive the test data.
+ *
+ * @example
+ * given([1,2,3], [3,2,1]).it("Has invariant sum", (a,b,c) => assert.strictEqual(a+b+c, 6));
+ */
+export function given<P1, P2, P3>(first: { 0: P1, 1: P2, 2: P3 } | { 0: P1, 1: P2, 2: P3 }[], ...params: { 0: P1, 1: P2, 2: P3 }[]): MochaGivenMethods3<P1, P2, P3>;
+
+/**
+ * Defines set of test data for a test case.
+ *
+ * @param { Tuple | Tuple[] } first
+ *     Values to pass to the test. If the arguments themselves are arrays,
+ *     they will be passed as multiple arguments to the test function.
+ *     If a data item is an object, the "description" property is used
+ *     to construct the individual test name.
+ *
+ * @param { Tuple[] } params
+ *     Additional values to pass to the test.
+ *
+ * @returns
+ *     Fluent interface to define the test that will receive the test data.
+ *
+ * @example
+ * given([1,2], [2,1]).it("Has invariant sum", (a,b) => assert.strictEqual(a+b, 3));
+ */
+export function given<P1, P2>(first: { 0: P1, 1: P2 } | { 0: P1, 1: P2 }[], ...params: { 0: P1, 1: P2 }[]): MochaGivenMethods2<P1, P2>;
+
+/**
+ * Defines set of test data for a test case.
+ *
+ * @param { any[] } params
+ *     Values to pass to the test. If a data item is an object, the "description"
+ *     property is used to construct the individual test name.
+ *
+ * @returns
+ *     Fluent interface to define the test that will receive the test data.
+ *
+ * @example
+ * const data = [1,2,3,4];
+ * given(data).it("Is a number", value => assert(typeof value === "number"));
+ */
+export function given<P1>(params: P1[]): MochaGivenMethods1<P1>;
+
+/**
+ * Defines set of test data for a test case.
+ *
+ * @param { any[] } params
+ *     Values to pass to the test. If a data item is an object, the "description"
+ *     property is used to construct the individual test name.
+ *
+ * @returns
+ *     Fluent interface to define the test that will receive the test data.
+ *
+ * @example
+ * given(1,2,3,4).it("Is a number", value => assert(typeof value === "number"));
+ */
+export function given<P1>(...params: P1[]): MochaGivenMethods1<P1>;
+
+
+
+/** Signature of Mocha "done" handler that must be called at the end of asynchronous calls chain in order for the test to pass. */
+type DoneHandler = { (): void };
+
+/** Fluent interface returned by "givenAsync". */
+interface MochaGivenAsyncMethods3<P1, P2, P3> {
+    /** Defines an async test case (for use with BDD interface). */
+    it(title: string, test: (done: DoneHandler, p1: P1, p2: P2, p3: P3) => void): any;
+
+    /** Defines an async test case (for use with TDD & qunit interfaces). */
+    test(title: string, test: (done: DoneHandler, p1: P1, p2: P2, p3: P3) => void): any;
+}
+
+/** Fluent interface returned by "givenAsync". */
+interface MochaGivenAsyncMethods2<P1, P2> {
+    /** Defines an async test case (for use with BDD interface). */
+    it(title: string, test: (done: DoneHandler, p1: P1, p2: P2) => void): any;
+
+    /** Defines an async test case (for use with TDD & qunit interfaces). */
+    test(title: string, test: (done: DoneHandler, p1: P1, p2: P2) => void): any;
+}
+
+/** Fluent interface returned by "givenAsync". */
+interface MochaGivenAsyncMethods1<P1> {
+    /** Defines an async test case (for use with BDD interface). */
+    it(title: string, test: (done: DoneHandler, p1: P1) => void): any;
+
+    /** Defines an async test case (for use with TDD & qunit interfaces). */
+    test(title: string, test: (done: DoneHandler, p1: P1) => void): any;
+}
+
+
+/**
+ * Defines set of test data for an asynchronous test case.
+ *
+ * @param { Tuple | Tuple[] } first
+ *     Values to pass to the test. If the arguments themselves are arrays,
+ *     they will be passed as multiple arguments to the test function.
+ *     If a data item is an object, the "description" property is used
+ *     to construct the individual test name.
+ *
+ * @param { Tuple[] } params
+ *     Additional values to pass to the test.
+ *
+ * @returns
+ *     Fluent interface to define the asynchronous test that will receive the test data.
+ *
+ * @example
+ * givenAsync([1,2,3], [3,2,1]).it("Has invariant sum", (done,a,b,c) => { assert.strictEqual(a+b+c, 6); done(); });
+ */
+export function givenAsync<P1, P2, P3>(first: { 0: P1, 1: P2, 2: P3 } | { 0: P1, 1: P2, 2: P3 }[], ...params: { 0: P1, 1: P2, 2: P3 }[]): MochaGivenAsyncMethods3<P1, P2, P3>;
+
+/**
+ * Defines set of test data for an asynchronous test case.
+ *
+ * @param { Tuple | Tuple[] } first
+ *     Values to pass to the test. If the arguments themselves are arrays,
+ *     they will be passed as multiple arguments to the test function.
+ *     If a data item is an object, the "description" property is used
+ *     to construct the individual test name.
+ *
+ * @param { Tuple[] } params
+ *     Additional values to pass to the test.
+ *
+ * @returns
+ *     Fluent interface to define the asynchronous test that will receive the test data.
+ *
+ * @example
+ * givenAsync([1,2], [2,1]).it("Has invariant sum", (done,a,b) => { assert.strictEqual(a+b, 3); done(); });
+ */
+export function givenAsync<P1, P2>(first: { 0: P1, 1: P2 } | { 0: P1, 1: P2 }[], ...params: { 0: P1, 1: P2 }[]): MochaGivenAsyncMethods2<P1, P2>;
+
+/**
+ * Defines set of test data for an asynchronous test case.
+ *
+ * @param { any[] } params
+ *     Values to pass to the test. If a data item is an object, the "description"
+ *     property is used to construct the individual test name.
+ *
+ * @returns
+ *     Fluent interface to define the asynchronous test that will receive the test data.
+ *
+ * @example
+ * const data = [1,2,3,4];
+ * givenAsync(data).it("Is a number", (done,value) => { assert(typeof value === "number"); done(); });
+ */
+export function givenAsync<P1>(params: P1[]): MochaGivenAsyncMethods1<P1>;
+
+/**
+ * Defines set of test data for an asynchronous test case.
+ *
+ * @param { any[] } params
+ *     Values to pass to the test. If a data item is an object, the "description"
+ *     property is used to construct the individual test name.
+ *
+ * @returns
+ *     Fluent interface to define the asynchronous test that will receive the test data.
+ *
+ * @example
+ * givenAsync(1,2,3,4).it("Is a number", (done,value) => { assert(typeof value === "number"); done(); });
+ */
+export function givenAsync<P1>(...params: P1[]): MochaGivenAsyncMethods1<P1>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,27 @@
+// TypeScript typings for "mocha-testdata@1.1.3".
+
+interface MochaGiven {
+    <P1, P2, P3>(...params: { 0: P1, 1: P2, 2: P3 }[]): MochaGivenMethods3<P1, P2, P3>;
+    <P1, P2>(...params: { 0: P1, 1: P2 }[]): MochaGivenMethods2<P1, P2>;
+    <P1>(...params: P1[]): MochaGivenMethods1<P1>;
+}
+
+interface MochaGivenMethods3<P1, P2, P3> {
+    it(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
+    test(title: string, test: (p1: P1, p2: P2, p3: P3) => void): any;
+}
+
+interface MochaGivenMethods2<P1, P2> {
+    it(title: string, test: (p1: P1, p2: P2) => void): any;
+    test(title: string, test: (p1: P1, p2: P2) => void): any;
+}
+
+interface MochaGivenMethods1<P1> {
+    it(title: string, test: (p1: P1) => void): any;
+    test(title: string, test: (p1: P1) => void): any;
+}
+
+declare module "mocha-testdata" {
+    const given: MochaGiven;
+    export = given;
+}

--- a/index.js
+++ b/index.js
@@ -73,3 +73,7 @@ function testData(async) {
 
 module.exports = testData.bind(null, false);
 module.exports.async = testData.bind(null, true);
+
+// named exports as per TypeScript typings
+module.exports.given = module.exports;
+module.exports.givenAsync = module.exports.async;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "gulp-mocha": "^2.2",
     "gulp-taskfromstreams": "^1.0",
     "gulp-util": "^3.0",
+    "jshint": "^2.9",
     "mocha": "^2.4",
     "monitorctrlc": "^1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-testdata",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "description": "Multiple test cases per mocha test",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "mocha-testdata",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Multiple test cases per mocha test",
   "license": "MIT",
   "main": "index.js",
+  "typings": "index.d.ts",
   "repository": "pandell/mocha-testdata",
   "author": {
     "name": "Pandell Technology",
@@ -34,6 +35,7 @@
     "given"
   ],
   "scripts": {
+    "clobber": "git clean -fdx || echo.",
     "lint": "gulp lint",
     "start": "gulp watch",
     "test": "gulp test"
@@ -44,14 +46,14 @@
   "homepage": "https://github.com/pandell/mocha-testdata",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "chalk": "0.*",
+    "chalk": "^1.1",
     "gulp": "^3.8",
-    "gulp-jshint": "^1.8",
+    "gulp-jshint": "^2.0",
     "gulp-jslint-simple": "^1.0",
-    "gulp-mocha": "^1.0",
+    "gulp-mocha": "^2.2",
     "gulp-taskfromstreams": "^1.0",
     "gulp-util": "^3.0",
-    "mocha": "^1.21",
+    "mocha": "^2.4",
     "monitorctrlc": "^1.0"
   }
 }


### PR DESCRIPTION
- Add non-ambient TypeScript typings
- Add "clobber" script
- Update outdated dependencies
- Bump version to 1.1.3

---

The new non-ambient typings support the following use-cases:

```ts
import { given, givenAsync } from "mocha-testdata";

// simple data
given(1, 2, 3, 4).it("One", arg => arg);
givenAsync(1, 2, 3, 4).it("Two", (done, arg) => done());

// simple predefined data
const data = [1, 2, 3, 4];
given(data).it("Three", arg => arg);
givenAsync(data).it("Four", (done, arg) => done());

// complex data
given([1, 2], [3, 4]).it("Five", (a, b) => a);
givenAsync([1, 2], [3, 4]).it("Six", (done, a, b) => done());

// complex predefined data
const complexData: { 0: number, 1: number }[] = [[1, 2], [3, 4]]; // explicit typing is required here, type inference is not good enough in TypeScript 1.8.9
given(complexData).it("Seven", (a, b) => a);
givenAsync(complexData).it("Eight", (done, a, b) => done());

// structured data
given({ a: 1, b: 2 }, { a: 1, b: 2 }).it("Nine", arg => arg.a);
givenAsync({ a: 1, b: 2 }, { a: 1, b: 2 }).it("Ten", (done, arg) => arg.a && done());

// structured predefined data
const structuredData = [{ a: 1, b: 2 }, { a: 1, b: 2 }];
given(structuredData).it("Eleven", arg => arg.a);
givenAsync(structuredData).it("Twelve", (done, arg) => arg.a && done());
```